### PR TITLE
Update personalize cdp/edge timeout

### DIFF
--- a/src/sxastarter/.env
+++ b/src/sxastarter/.env
@@ -67,7 +67,7 @@ NEXT_PUBLIC_CDP_CLIENT_KEY=
 NEXT_PUBLIC_CDP_POINTOFSALE=
 
 # Timeout (ms) for Sitecore CDP requests to respond within. Default is 250.
-PERSONALIZE_MIDDLEWARE_CDP_TIMEOUT=
+PERSONALIZE_MIDDLEWARE_CDP_TIMEOUT=400
 
 # Timeout (ms) for Sitecore Experience Edge requests to respond within. Default is 250.
-PERSONALIZE_MIDDLEWARE_EDGE_TIMEOUT=
+PERSONALIZE_MIDDLEWARE_EDGE_TIMEOUT=400


### PR DESCRIPTION
Increasing the edge/CDP timeout environment variables value to 400 as with 250 (previous timeout) the request gets timeout and the user always gets the default experience.