### PR TITLE
Specify ser push command in startup script to match the comment above it

### DIFF
--- a/up.ps1
+++ b/up.ps1
@@ -104,7 +104,7 @@ Write-Host "Rebuilding indexes ..." -ForegroundColor Green
 dotnet sitecore index rebuild
 
 Write-Host "Pushing Default rendering host configuration" -ForegroundColor Green
-dotnet sitecore ser push
+dotnet sitecore ser push -i RenderingHost
 
 Write-Host "Pushing sitecore API key" -ForegroundColor Green
 & docker\build\cm\templates\import-templates.ps1 -RenderingSiteName "xmcloudpreview" -SitecoreApiKey $sitecoreApiKey


### PR DESCRIPTION
I think we should either remove this ser push command, or make it specific, to prevent unwanted serialization of other items, and make pulling and pushing a deliberate action. See my blog post for further details on the use case [https://www.robhabraken.nl/index.php/4662/default-scs-in-xm-cloud/](https://www.robhabraken.nl/index.php/4662/default-scs-in-xm-cloud/)