### PR TITLE
Update sitecore.json: Raise XMCloud version to 1.1.120

### DIFF
--- a/sitecore.json
+++ b/sitecore.json
@@ -8,7 +8,7 @@
     "Sitecore.DevEx.Extensibility.Publishing@5.2.113",
     "Sitecore.DevEx.Extensibility.Indexing@5.2.113",
     "Sitecore.DevEx.Extensibility.ResourcePackage@5.2.113",
-    "Sitecore.DevEx.Extensibility.XMCloud@1.1.99"
+    "Sitecore.DevEx.Extensibility.XMCloud@1.1.120"
   ],
   "serialization": {
     "defaultMaxRelativeItemPathLength": 100,


### PR DESCRIPTION
There is 1.1.120 version with new commands for XMCloud CLI:

https://cloudsmith.io/~sitecore/repos/resources/packages/detail/nuget/Sitecore.DevEx.Extensibility.XMCloud/1.1.120/